### PR TITLE
Update to Minetest release 5.6.1

### DIFF
--- a/.github/workflows/multiarch.yaml
+++ b/.github/workflows/multiarch.yaml
@@ -36,9 +36,9 @@ jobs:
               linux/arm64
           - dockerfile: Dockerfile
             args: |-
-              MINETEST_VERSION=5.6.0
-              MINETEST_GAME_VERSION=5.6.0
-              MINETEST_IRRLICHT_VERSION=1.9.0mt7
+              MINETEST_VERSION=5.6.1
+              MINETEST_GAME_VERSION=5.6.1
+              MINETEST_IRRLICHT_VERSION=1.9.0mt8
             tags: |-
               stable
               stable-5

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG MINETEST_IRRLICHT_VERSION=master
 ARG MINETOOLS_VERSION=v0.2.2
 # Using a specific and newer LuaJIT commit to fix several ARM issues
 # and crashes.
-ARG LUAJIT_VERSION=a7d0265480c662964988f83d4e245bf139eb7cc0
+ARG LUAJIT_VERSION=dad04f1754723e76ba9dcf9f401f3134a0cd3972
 
 # Install all build-dependencies
 RUN apt-get update &&\


### PR DESCRIPTION
Update from newer versions of both LuaJIT v2.1 branch and Minetest 5.6.1