### PR TITLE
Update minetest_game version

### DIFF
--- a/.github/workflows/multiarch.yaml
+++ b/.github/workflows/multiarch.yaml
@@ -36,7 +36,7 @@ jobs:
           - dockerfile: Dockerfile
             args: |-
               MINETEST_VERSION=5.8.0
-              MINETEST_GAME_VERSION=5.7.0
+              MINETEST_GAME_VERSION=5.8.0
               MINETEST_IRRLICHT_VERSION=1.9.0mt13
             tags: |-
               stable


### PR DESCRIPTION
The new minetest_game came out on December 17th, that is, the release is no longer synchronized with minetest