### PR TITLE
feat: updated to Minetest 5.9 and 5.10-dev

### DIFF
--- a/.github/workflows/multiarch.yaml
+++ b/.github/workflows/multiarch.yaml
@@ -25,9 +25,10 @@ jobs:
             args: |-
               MINETEST_VERSION=master
               MINETEST_GAME_VERSION=master
-              MINETEST_IRRLICHT_VERSION=master
+              MINETEST_IRRLICHT_VERSION=none
+              LUAJIT_VERSION=v2.1
             tags: |-
-              5.8.0-dev
+              5.10.0-dev
               unstable
               dev
             platforms: |-
@@ -35,9 +36,9 @@ jobs:
               linux/arm64
           - dockerfile: Dockerfile
             args: |-
-              MINETEST_VERSION=5.8.0
-              MINETEST_GAME_VERSION=5.8.0
-              MINETEST_IRRLICHT_VERSION=1.9.0mt13
+              MINETEST_VERSION=5.9.0
+              MINETEST_GAME_VERSION=4e402ec39fb1852b148e62637df0b72ae70ecd7d
+              LUAJIT_VERSION=4e402ec39fb1852b148e62637df0b72ae70ecd7d
             tags: |-
               stable
               stable-5

--- a/.github/workflows/multiarch.yaml
+++ b/.github/workflows/multiarch.yaml
@@ -38,7 +38,7 @@ jobs:
             args: |-
               MINETEST_VERSION=5.9.0
               MINETEST_GAME_VERSION=4e402ec39fb1852b148e62637df0b72ae70ecd7d
-              LUAJIT_VERSION=4e402ec39fb1852b148e62637df0b72ae70ecd7d
+              LUAJIT_VERSION=f725e44cda8f359869bf8f92ce71787ddca45618
             tags: |-
               stable
               stable-5

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,14 +27,14 @@ RUN mkdir -p /usr/src &&\
         https://github.com/minetest/minetest.git \
         /usr/src/minetest &&\
     rm -rf /usr/src/minetest/.git
-RUN git clone --depth=1 -b ${MINETEST_GAME_VERSION} \
-        https://github.com/minetest/minetest_game.git \
-        /usr/src/minetest/games/minetest_game
 RUN if [ "${MINETEST_IRRLICHT_VERSION}" != "none" ] ; then \
         git clone --depth=1 -b ${MINETEST_IRRLICHT_VERSION} \
         https://github.com/minetest/irrlicht \
         /usr/src/minetest/lib/irrlichtmt ; \
     fi
+RUN git clone --depth=1 https://github.com/minetest/minetest_game.git \
+        /usr/src/minetest/games/minetest_game &&\
+    git -C /usr/src/minetest/games/minetest_game checkout ${MINETEST_GAME_VERSION}
 RUN git clone \
         https://github.com/LuaJIT/LuaJIT.git \
         /usr/src/luajit &&\

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+SHELL=bash
 IMAGE=ghcr.io/ronoaldo/minetestserver
 TAG=latest
 
@@ -6,3 +7,15 @@ build:
 
 run: build
 	docker run --rm --name minetestserver -it -P ${IMAGE}:${TAG}
+
+build-workflow-matrix:
+	@for i in $$(seq 0 1) ; do \
+		MATRIX="$$(yq -r ".jobs.\"multiarch-build\".strategy.matrix.include[$$i] | .args" \
+			< .github/workflows/multiarch.yaml)" ;\
+		while read arg ; do export ARGS="$${ARGS} --build-arg $${arg}" ; done <<<"$${MATRIX}"; \
+		docker buildx build \
+			$${ARGS} \
+			--file Dockerfile \
+			--platform linux/amd64 \
+			. ; \
+	done

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+IMAGE=ghcr.io/ronoaldo/minetestserver
+TAG=latest
+
+build:
+	docker build -t ${IMAGE}:${TAG} .
+
+run: build
+	docker run --rm --name minetestserver -it -P ${IMAGE}:${TAG}


### PR DESCRIPTION
This update also fixes two other issues: LuaJIT versioning and Minetest Game no longer being the default.

- Server will start with a simple `docker run` on 5.9+
- No longer builds Irrlicht as a standalone lib.